### PR TITLE
Fix/entity detection input sentences

### DIFF
--- a/annotators/entity_detection/server.py
+++ b/annotators/entity_detection/server.py
@@ -34,7 +34,7 @@ DOUBLE_SPACES = re.compile(r"\s+")
 
 def get_result(request):
     st_time = time.time()
-    last_utterances = request.json.get("last_utterances", [])
+    last_utterances = request.json.get("sentences", [])
     logger.info(f"input (the last utterances): {last_utterances}")
 
     utterances_list = []

--- a/annotators/entity_detection/server.py
+++ b/annotators/entity_detection/server.py
@@ -39,13 +39,12 @@ def get_result(request):
 
     utterances_list = []
     utterances_nums = []
-    for n, utterances in enumerate(last_utterances):
-        for elem in utterances:
-            if len(elem) > 0:
-                if elem[-1] not in {".", "!", "?"}:
-                    elem = f"{elem}."
-                utterances_list.append(elem.lower())
-                utterances_nums.append(n)
+    for n, utterance in enumerate(last_utterances):
+        if len(utterance) > 0:
+            if utterance[-1] not in {".", "!", "?"}:
+                utterance = f"{utterance}."
+            utterances_list.append(utterance.lower())
+            utterances_nums.append(n)
 
     utt_entities_batch = [{} for _ in last_utterances]
     utt_entities = {}

--- a/annotators/entity_detection/server.py
+++ b/annotators/entity_detection/server.py
@@ -20,6 +20,7 @@ try:
     entity_detection_alexa = build_model(config_name, download=True)
     entity_detection_lcquad = build_model("entity_detection_lcquad.json", download=True)
     entity_detection_alexa(["what is the capital of russia"])
+    entity_detection_lcquad(["what is the capital of russia"])
     logger.info("entity detection model is loaded.")
 except Exception as e:
     sentry_sdk.capture_exception(e)

--- a/annotators/entity_detection/test_entity_detection.py
+++ b/annotators/entity_detection/test_entity_detection.py
@@ -5,8 +5,8 @@ def main():
     url = "http://0.0.0.0:8103/respond"
 
     request_data = [
-        {"last_utterances": [["what is the capital of russia?"]]},
-        {"last_utterances": [["let's talk about politics."]]},
+        {"sentences": ["what is the capital of russia?"]},
+        {"sentences": ["let's talk about politics."]},
     ]
 
     gold_results = [

--- a/assistant_dists/dream/pipeline_conf.json
+++ b/assistant_dists/dream/pipeline_conf.json
@@ -269,7 +269,7 @@
                     "timeout": 1,
                     "url": "http://entity-detection:8103/respond"
                 },
-                "dialog_formatter": "state_formatters.dp_formatters:ner_formatter_dialog",
+                "dialog_formatter": "state_formatters.dp_formatters:preproc_last_human_utt_dialog",
                 "response_formatter": "state_formatters.dp_formatters:simple_formatter_service",
                 "state_manager_method": "add_annotation",
                 "required_previous_services": [


### PR DESCRIPTION
Была проблема, что entity detection на вход принимал реплики, разделенные на предложения. Поэтому не работали аннотации сущностями для гипотез бота. 
В этом пулл-реквесте заменено использование  реплик, разделенных на предложения, на просто реплики. Также добавлен тестовый запрос после подгрузки модели, так как обработка первого запроса занимает длительное время по сравнению с последующими.